### PR TITLE
Add advice to be in the correct directory

### DIFF
--- a/index.html
+++ b/index.html
@@ -1810,7 +1810,7 @@ $ jsonld format -q http://localhost:9200/loc/work/c000000026/_source
 									<td>Edit new file</td>
 									<td>
 										<pre><code class="bash" data-trim>
-$ gedit search.html &amp;
+$ cd data; gedit search.html &amp;
 										</code></pre>
 									</td>
 								</tr>


### PR DESCRIPTION
This prevents to override the root's search.html.