### PR TITLE
Use latest node

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,13 @@ RUN apt-get install -y make
 RUN apt-get install -y g++
 
 # install node:
-RUN apt-get install -y npm
+ENV NVM_DIR /usr/local/nvm
+ENV NODE_VERSION v16.17.0
+RUN mkdir -p /usr/local/nvm && apt-get update && echo "y" | apt-get install curl
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
+RUN /bin/bash -c "source $NVM_DIR/nvm.sh && nvm install $NODE_VERSION && nvm use --delete-prefix $NODE_VERSION"
+ENV NODE_PATH $NVM_DIR/versions/node/$NODE_VERSION/bin
+ENV PATH $NODE_PATH:$PATH
 
 # install the hbz jsonld-cli fork:
 RUN git clone https://github.com/hbz/jsonld-cli.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get install -y g++
 
 # install node:
 ENV NVM_DIR /usr/local/nvm
-ENV NODE_VERSION v16.17.0
+ENV NODE_VERSION v18.16.1
 RUN mkdir -p /usr/local/nvm && apt-get update && echo "y" | apt-get install curl
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
 RUN /bin/bash -c "source $NVM_DIR/nvm.sh && nvm install $NODE_VERSION && nvm use --delete-prefix $NODE_VERSION"

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,14 +15,8 @@ RUN apt-get install -y apt-utils
 RUN apt-get install -y make
 RUN apt-get install -y g++
 
-# install node (8.x or higher):
-RUN curl -sL https://deb.nodesource.com/setup_8.x > setup_8.x
-RUN sync
-#RUN chmod 755 ./setup_8.x && ./setup_8.x
-RUN chmod 755 ./setup_8.x 
-RUN sync
-RUN ./setup_8.x
-RUN apt-get install -y nodejs
+# install node:
+RUN apt-get install -y npm
 
 # install the hbz jsonld-cli fork:
 RUN git clone https://github.com/hbz/jsonld-cli.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:18:04
 
 WORKDIR /home/loud
 ENV DEBIAN_FRONTEND noninteractive
@@ -15,14 +15,14 @@ RUN apt-get install -y apt-utils
 RUN apt-get install -y make
 RUN apt-get install -y g++
 
-# install node:
-ENV NVM_DIR /usr/local/nvm
-ENV NODE_VERSION v18.16.1
-RUN mkdir -p /usr/local/nvm && apt-get update && echo "y" | apt-get install curl
-RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
-RUN /bin/bash -c "source $NVM_DIR/nvm.sh && nvm install $NODE_VERSION && nvm use --delete-prefix $NODE_VERSION"
-ENV NODE_PATH $NVM_DIR/versions/node/$NODE_VERSION/bin
-ENV PATH $NODE_PATH:$PATH
+# install node (8.x or higher):
+RUN curl -sL https://deb.nodesource.com/setup_8.x > setup_8.x
+RUN sync
+#RUN chmod 755 ./setup_8.x && ./setup_8.x
+RUN chmod 755 ./setup_8.x 
+RUN sync
+RUN ./setup_8.x
+RUN apt-get install -y nodejs
 
 # install the hbz jsonld-cli fork:
 RUN git clone https://github.com/hbz/jsonld-cli.git


### PR DESCRIPTION
Upgrade nodejs as 8 is deprecated:

```
 > [elag2019-bootcamp 17/35] RUN ./setup_8.x:                                                                                                                                                                                                                             
#0 0.288                                                                                                                                                                                                                                                                  
#0 0.288 ================================================================================                                                                                                                                                                                 
#0 0.288 ================================================================================                                                                                                                                                                                 
#0 0.288                                                                                                                                                                                                                                                                  
#0 0.288                               DEPRECATION WARNING                            
#0 0.288 
#0 0.288   Node.js 8.x LTS Carbon is no longer actively supported!
#0 0.288 
#0 0.288   You will not receive security or critical stability updates for this version.
#0 0.288 
#0 0.288   You should migrate to a supported version of Node.js as soon as possible.
#0 0.288   Use the installation script that corresponds to the version of Node.js you
#0 0.288   wish to install. e.g.
#0 0.288 
#0 0.288    * https://deb.nodesource.com/setup_12.x — Node.js 12 LTS "Erbium"
#0 0.288    * https://deb.nodesource.com/setup_14.x — Node.js 14 LTS "Fermium" (recommended)
#0 0.288    * https://deb.nodesource.com/setup_16.x — Node.js 16 "Gallium"
#0 0.288 
#0 0.288   Please see https://github.com/nodejs/Release for details about which
#0 0.288   version may be appropriate for you.
#0 0.288 
#0 0.288   The NodeSource Node.js distributions repository contains
#0 0.288   information both about supported versions of Node.js and supported Linux
#0 0.288   distributions. To learn more about usage, see the repository:
#0 0.288     https://github.com/nodesource/distributions
#0 0.288 
#0 0.288 ================================================================================
#0 0.288 ================================================================================
#0 0.288 
#0 0.288 Continuing in 20 seconds ...
#0 0.288 
#0 20.27 
#0 20.27 ## Installing the NodeSource Node.js 8.x LTS Carbon repo...
#0 20.27 
#0 20.28 
#0 20.28 ## Populating apt-get cache...
#0 20.28 
#0 20.28 + apt-get update
#0 20.72 Hit:1 http://archive.ubuntu.com/ubuntu jammy InRelease
#0 20.76 Hit:2 http://security.ubuntu.com/ubuntu jammy-security InRelease
#0 20.81 Hit:3 http://archive.ubuntu.com/ubuntu jammy-updates InRelease
#0 20.92 Hit:4 http://archive.ubuntu.com/ubuntu jammy-backports InRelease
#0 21.27 Reading package lists...
#0 22.40 
#0 22.40 ## Installing packages required for setup: lsb-release...
#0 22.40 
#0 22.40 + apt-get install -y lsb-release > /dev/null 2>&1
#0 31.87 
#0 31.87 ## Confirming "jammy" is supported...
#0 31.87 
#0 31.87 + curl -sLf -o /dev/null 'https://deb.nodesource.com/node_8.x/dists/jammy/Release'
#0 33.43 
#0 33.43 ## Your distribution, identified as "jammy", is not currently supported, please contact NodeSource at https://github.com/nodesource/distributions/issues if you think this is incorrect or would like your distribution to be considered for support
#0 33.43 
```